### PR TITLE
feat: ingress nginx kustomize example

### DIFF
--- a/examples/kustomize-nginx-ingress/README.md
+++ b/examples/kustomize-nginx-ingress/README.md
@@ -1,0 +1,41 @@
+# NGINX Ingress
+
+## Install Ingress Controller with Helm
+- add repo:
+  ```console
+  helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+  helm repo update
+  ```
+- deploy NGINX ingress controller (this creates a TCP/UDP load balancer in GCP)
+- wait until you get an external IP
+  ```console
+  helm install ingress-nginx ingress-nginx/ingress-nginx
+  ```
+- add the following snippet to `network.tf`
+  ```
+  resource "google_compute_firewall" "pods_and_master" {
+    name        = "allow-pods-and-master-ipv4-cidrs"
+    network     = google_compute_network.k8s_vpc.name
+    description = "Allow pods and master to communicate with each other"
+
+    direction = "INGRESS"
+
+    allow {
+      protocol = "all"
+    }
+
+    # https://cloud.google.com/community/tutorials/nginx-ingress-gke
+    source_ranges = [var.cluster_ipv4_cidr_block, var.services_ipv4_cidr_block, var.master_ipv4_cidr_block]
+  }
+  ```
+- request a tls cert from letsencrypt
+  ```
+  mkdir -p certbot/logs certbot/config
+  cd certbot
+  certbot certonly --work-dir . --logs-dir ./logs --config-dir ./config --manual --preferred-challenges=dns --agree-tos -d '*.example.com' -d 'example.com'
+  # COMPLETE DNS CHALLENGES TO GET ISSUED CERTIFICATE
+  ```
+- deploy the example application
+  ```console
+  kustomize build . | kubectl apply -f -
+  ```

--- a/examples/kustomize-nginx-ingress/ingress.yaml
+++ b/examples/kustomize-nginx-ingress/ingress.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-test
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 80
+            path: /
+  tls:
+    - hosts:
+      - example.com
+      secretName: tls-cert

--- a/examples/kustomize-nginx-ingress/kustomization.yaml
+++ b/examples/kustomize-nginx-ingress/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: nginx-test
+
+labels:
+  - includeSelectors: true
+    pairs:
+      app: nginx-test
+
+resources:
+  - namespace.yaml
+  - nginx-deployment.yaml
+  - nginx-svc.yaml
+  - ingress.yaml
+
+secretGenerator:
+- name: tls-cert
+  files:
+  - tls.crt=certbot/config/live/example.com/fullchain.pem
+  - tls.key=certbot/config/live/example.com/privkey.pem
+  type: "kubernetes.io/tls"

--- a/examples/kustomize-nginx-ingress/namespace.yaml
+++ b/examples/kustomize-nginx-ingress/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-test

--- a/examples/kustomize-nginx-ingress/nginx-deployment.yaml
+++ b/examples/kustomize-nginx-ingress/nginx-deployment.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - name: nginx-port
+          containerPort: 80

--- a/examples/kustomize-nginx-ingress/nginx-svc.yaml
+++ b/examples/kustomize-nginx-ingress/nginx-svc.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: nginx-port


### PR DESCRIPTION
I started deploying this because I wanted to learn GKE and I was tired of paying AWS $200 a month for a simple cluster.  I didn't want to have a load balancer per service.  On AWS you can annotate a group name and priority on your ingress to share one load balancer and merge the rules for it so multiple services across multiple namespaces can share one alb.  Anyways, there is not an equivalent functionality for GKE, so I opted for ingress nginx, but I noticed the example included here was not working, and deploying an `Ingress` with class `nginx` failing with:

```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking/v1/ingresses?timeout=10s": dial tcp 10.0.0.27:8443: i/o timeout
```

I found some google docs and fixed the issue by adding a firewall rule in the network.  Since it's not required for the cluster to work I left it out of `network.tf` in this PR and just included it as a snippet in the readme.