### PR TITLE
Add Trivy Operator example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.16.4] - 2024-04-23
+### Added
+- `examples/trivy-operator`
+### Changed
+- Some `NodePort` service types in the examples were changed to `ClusterIP` 
+
 ## [0.16.3] - 2024-04-02
 ### Added
 - Added `description` to output values

--- a/examples/nginx-ingress/currency.yaml
+++ b/examples/nginx-ingress/currency.yaml
@@ -15,7 +15,7 @@ spec:
     targetPort: 8080
   selector:
      app: currency
-  type: NodePort
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/nginx-ingress/payments.yaml
+++ b/examples/nginx-ingress/payments.yaml
@@ -15,7 +15,7 @@ spec:
     targetPort: 8080
   selector:
      app: payments
-  type: NodePort
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/nginx-ingress/web.yaml
+++ b/examples/nginx-ingress/web.yaml
@@ -15,7 +15,7 @@ spec:
     targetPort: 8080
   selector:
      app: web
-  type: NodePort
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/examples/opa-gatekeeper/README.md
+++ b/examples/opa-gatekeeper/README.md
@@ -6,9 +6,11 @@ helm repo update
 
 helm search repo gatekeeper -l
 
-helm install --namespace gatekeeper-system [RELEASE_VERSION] gatekeeper/gatekeeper --create-namespace
+helm install gatekeeper gatekeeper/gatekeeper \
+  --namespace gatekeeper-system \
+  --create-namespace \
+  --version 3.15.1
 ```
-
 
 ## How-to
 You first need to define a `ContraintsTemplate` which is written in [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) and is used to define you policy.  Afterwards, you can create rules based on these policies.  Included in this directory is a couple of policies as well as rules that are built upon these policies.

--- a/examples/trivy-operator/README.md
+++ b/examples/trivy-operator/README.md
@@ -1,0 +1,48 @@
+# [Trivy Operator](https://github.com/aquasecurity/trivy-operator) 
+Trivy Operator let's you continuously scan your Kubernetes (GKE) cluster for any security-related issues.  It's a great tool for any environments and industries where compliance is critical (or maybe you're just really security-conscious).
+
+## Install
+- install via helm:
+```console
+helm repo add aqua https://aquasecurity.github.io/helm-charts/
+helm repo update
+
+helm search repo aqua/trivy-operator -l
+
+helm install trivy-operator aqua/trivy-operator \
+  --namespace trivy-system \
+  --create-namespace \
+  --version 0.22.0 \
+  --set="excludeNamespaces=gke-managed-system\,kube-system"
+```
+
+**NOTE:** you need to escape the comma for the lists if you are setting options in command line.  
+
+
+## Reports
+There are a variety of reports that the Trivy Operator can produce, including some of my favorites:
+- [RbacAssessmentReport](https://aquasecurity.github.io/trivy-operator/v0.20.0/docs/crds/rbacassessment-report/)
+- [ClusterComplianceReport](https://aquasecurity.github.io/trivy-operator/v0.20.0/docs/crds/clustercompliance-report/)
+- [ClusterVulnerabilityReport](https://aquasecurity.github.io/trivy-operator/v0.20.0/docs/crds/clustervulnerability-report/)
+- and much more!
+
+
+### NGINX Example
+Apply both NGINX deployment manifests.  Once they are deployed, list the `vulnerabilityreport` and `configauditreport` resources (don't forget the `-o wide` flag). Despite both being just a simple NGINX web server, the image type (Debian base vs Alpine base) as well as the config and security context settings make a huge difference. 
+
+#### Reports
+- [VulnerabilityReport](https://aquasecurity.github.io/trivy-operator/v0.20.0/docs/vulnerability-scanning/trivy/) (`kubectl get vulnerabilityreport --all-namespaces -o wide`):
+```
+NAMESPACE      NAME                                                  REPOSITORY                    TAG                SCANNER   AGE     CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
+default        replicaset-nginx-6bf45ff-nginx                        library/nginx                 latest             Trivy     15m     2          23     45       91    1
+mynginx        replicaset-nginx-unpriv-58b44548b6-nginx              nginxinc/nginx-unprivileged   1.25-alpine-slim   Trivy     39s     0          0      0        0     0
+```
+
+- [ConfigAuditReport](https://aquasecurity.github.io/trivy-operator/v0.20.0/docs/crds/configaudit-report/) (`kubectl get configauditreport --all-namespaces -o wide`):
+```
+NAMESPACE      NAME                                   SCANNER   AGE     CRITICAL   HIGH   MEDIUM   LOW
+default        replicaset-nginx-6bf45ff               Trivy     16m     0          3      8        13
+default        service-nginx-svc                      Trivy     5m44s   0          0      0        2
+mynginx        replicaset-nginx-unpriv-58b44548b6     Trivy     11s     0          1      5        2
+mynginx        service-nginx-unpriv-svc               Trivy     5m31s   0          0      0        2
+```

--- a/examples/trivy-operator/nginx-insecure.yaml
+++ b/examples/trivy-operator/nginx-insecure.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - name: web
+          containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: web

--- a/examples/trivy-operator/nginx-secure.yaml
+++ b/examples/trivy-operator/nginx-secure.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mynginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-unpriv
+  namespace: mynginx
+  labels:
+    app: nginx-unpriv
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-unpriv
+  template:
+    metadata:
+      labels:
+        app: nginx-unpriv
+    spec:
+      securityContext:
+        fsGroup: 2000
+      containers:
+      - name: nginx
+        image: nginxinc/nginx-unprivileged:1.25-alpine-slim
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - name: web
+          containerPort: 8080
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "64Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-unpriv-svc
+  namespace: mynginx
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx-unpriv
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: web


### PR DESCRIPTION
- added `examples/trivy-operator`
- updated `NodePort` service types in some examples to `ClusterIP` instead