### PR TITLE
Fix missing accelerator config default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -392,6 +392,7 @@ variable "guest_accelerator_config" {
     count              = optional(number, 0)
     gpu_driver_version = optional(string, "LATEST")
   })
+  default = {}
 
   validation {
     condition     = var.guest_accelerator_config.type == "nvidia-l4" #|| startswith(var.guest_accelerator_config.type, "ct")


### PR DESCRIPTION
This PR adds an empty default for the recently introduced accelerator config.

Otherwise the following error is thrown by `terraform plan` with the defaults in this repo:

```
│ Error: Invalid value for input variable
│
│   on variables.tf line 388:
│  388: variable "guest_accelerator_config" {
│
│ Unsuitable value for var.guest_accelerator_config set using an interactive prompt: object required, but have number.
```